### PR TITLE
Add bats tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Bats on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+      - name: Install Bats on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install bats-core
+      - name: Run tests
+        run: bats tests

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPHOME="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPHOME"
+}
+
+@test "bootstrap script syncs dotfiles" {
+  git() { :; }
+  export -f git
+  cd "$BATS_TEST_DIRNAME/.."
+  HOME="$TMPHOME" run bash bootstrap.sh --force
+  [ "$status" -eq 0 ]
+  [ -f "$TMPHOME/.bashrc" ]
+  [ -f "$TMPHOME/.bash_profile" ]
+}


### PR DESCRIPTION
## Summary
- add Bats test verifying bootstrap script copies dotfiles
- run tests on macOS and Linux via GitHub Actions

## Testing
- `bats tests/bootstrap.bats`

------
https://chatgpt.com/codex/tasks/task_e_686747a2c454832e865589da46e2d83f