### PR TITLE
Add Bats tests for macOS defaults

### DIFF
--- a/tests/macos.bats
+++ b/tests/macos.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+@test "macos script syntax is valid" {
+  run bash -n "$BATS_TEST_DIRNAME/../.macos"
+  [ "$status" -eq 0 ]
+}
+
+@test "macos disables natural scrolling" {
+  run grep -q 'com.apple.swipescrolldirection -bool false' "$BATS_TEST_DIRNAME/../.macos"
+  [ "$status" -eq 0 ]
+}
+
+@test "macos sets screenshot location" {
+  run grep -q 'com.apple.screencapture location -string "${HOME}/Desktop"' "$BATS_TEST_DIRNAME/../.macos"
+  [ "$status" -eq 0 ]
+}
+
+@test "macos sets highlight color" {
+  run grep -q 'AppleHighlightColor -string "0.764700 0.976500 0.568600"' "$BATS_TEST_DIRNAME/../.macos"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add a new `macos.bats` suite with simple checks

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6867498a11ac832e923091faeeab23de