### PR TITLE
🐛 fix: 🔧 put asdf shims on PATH (asdf 0.16+ removed asdf.sh)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -70,8 +70,8 @@ compdef _killall_completion killall
 # Runtime environment managers.
 # asdf is the preferred multi-language manager; the per-language managers below
 # are no-ops when not installed, so both setups coexist safely.
-if (( $+commands[brew] )) && [[ -f "$(brew --prefix asdf 2>/dev/null)/libexec/asdf.sh" ]]; then
-	source "$(brew --prefix asdf)/libexec/asdf.sh"
+if (( $+commands[asdf] )); then
+	export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 fi
 
 if (( $+commands[rbenv] )); then


### PR DESCRIPTION
## Summary

Fixes the asdf hookup in `.zshrc`. asdf's Go rewrite (0.16+; this machine is on 0.19) removed `libexec/asdf.sh`, so the `source` guard in `.zshrc` was always false and `~/.asdf/shims` never reached `PATH`. As a result `uv`/`python` resolved to the Homebrew copies and every project's `.tool-versions` pin was silently ignored.

The fix prepends `${ASDF_DATA_DIR:-$HOME/.asdf}/shims` to `PATH` directly, which is the supported setup for asdf 0.16+.

```diff
-if (( $+commands[brew] )) && [[ -f "$(brew --prefix asdf 2>/dev/null)/libexec/asdf.sh" ]]; then
-	source "$(brew --prefix asdf)/libexec/asdf.sh"
+if (( $+commands[asdf] )); then
+	export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 fi
```

## Testing

- New shell: `command -v uv` / `command -v python` now resolve through `~/.asdf/shims` rather than the Homebrew prefix.
- `.tool-versions` pins are honored again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
