### PR TITLE
✨ feat: GitHub inbox segment in the statusline

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -281,7 +281,8 @@ if [[ -n $toplevel ]]; then
 	# cache the block above keeps fresh — never fetched here (the render
 	# path runs every second and must stay pure-read). Count = todo
 	# (review requests, assignments, invites; persist until resolved on
-	# GitHub) + fyi (unread mentions/replies; clear when read there).
+	# GitHub) + fyi (open PRs/issues/discussions that @mention me; clear
+	# when the item closes or I unsubscribe from the thread).
 	# The hue says which kind, like the flags and arrows above: red means
 	# at least one todo (action owed), yellow means FYIs only (worth a
 	# look, nothing blocking). Hidden when zero, absent, or the cache is

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -282,19 +282,24 @@ if [[ -n $toplevel ]]; then
 	# path runs every second and must stay pure-read). Count = todo
 	# (review requests, assignments, invites; persist until resolved on
 	# GitHub) + fyi (unread mentions/replies; clear when read there).
-	# Hidden when zero, absent, or the cache is older than 25 min — a dead
-	# checker must not show a frozen count, and one find covers missing
-	# and stale in a single test.
+	# The hue says which kind, like the flags and arrows above: red means
+	# at least one todo (action owed), yellow means FYIs only (worth a
+	# look, nothing blocking). Hidden when zero, absent, or the cache is
+	# older than 25 min — a dead checker must not show a frozen count, and
+	# one find covers missing and stale in a single test.
 	inbox_file="${XDG_CACHE_HOME:-$HOME/.cache}/gh-inbox/inbox.json"
 	if [[ -n $(find "$inbox_file" -mmin -25 2>/dev/null) ]]; then
-		inbox=$(jq -r --arg r "$repo" \
-			'.repos[$r] | if . then .todo + .fyi else empty end' \
-			"$inbox_file" 2>/dev/null)
-		if [[ $inbox =~ ^[0-9]+$ ]] && (( inbox > 0 )); then
+		read -r inbox_todo inbox_fyi <<<"$(jq -r --arg r "$repo" \
+			'.repos[$r] | if . then "\(.todo) \(.fyi)" else empty end' \
+			"$inbox_file" 2>/dev/null)"
+		if [[ $inbox_todo =~ ^[0-9]+$ && $inbox_fyi =~ ^[0-9]+$ ]] &&
+			(( inbox_todo + inbox_fyi > 0 )); then
+			inbox=$(( inbox_todo + inbox_fyi ))
+			if (( inbox_todo > 0 )); then inbox_color=$red; else inbox_color=$yellow; fi
 			if [[ -n $inbox_icon ]]; then
-				out+=" ${grey}${inbox_icon}${reset}${yellow}${inbox}${reset}"
+				out+=" ${inbox_color}${inbox_icon}${inbox}${reset}"
 			else
-				out+=" ${grey}inbox${reset} ${yellow}${inbox}${reset}"
+				out+=" ${grey}inbox${reset} ${inbox_color}${inbox}${reset}"
 			fi
 		fi
 	fi

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Claude Code status line:
-#   (venv) (direnv:dir) org/repo[/subdir] on branch [+!?$] ↑N↓N pr N as @ghuser via Model (effort) ctx N% +N/-N <spinner>
+#   (venv) (direnv:dir) org/repo[/subdir] on branch [+!?$] ↑N↓N pr N as @ghuser inbox N via Model (effort) ctx N% +N/-N <spinner>
 # Git status flags: + staged, ! unstaged, ? untracked, $ stashed.
 #
 # Design rule: every segment is optional and self-hiding. Each probe carries
@@ -45,7 +45,8 @@ yellow=$'\033[33m' reset=$'\033[0m'
 # are literal UTF-8, not $'\u' escapes — macOS ships bash 3.2, which lacks
 # them. nerd needs a patched font: spinner U+EE06–U+EE0B, branch U+E0A0,
 # GitHub U+F09B, model U+F06A9, effort bolt U+F0E7, ctx gauge U+F04C5,
-# venv python U+E73C, direnv leaf U+F06C, pull request U+F407. Icons stand
+# venv python U+E73C, direnv leaf U+F06C, pull request U+F407, inbox bell
+# U+F009A. Icons stand
 # in for words, so
 # nerd drops the grey "via"/"ctx"/"pr" labels rather than decorating them,
 # and the venv/direnv segments drop their () text wrappers. braille renders
@@ -53,13 +54,13 @@ yellow=$'\033[33m' reset=$'\033[0m'
 case ${1-} in
 braille)
 	frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
-	branch_icon='' user_icon='@' model_icon='' effort_icon='' ctx_icon='' venv_icon='' direnv_icon='' pr_icon='' ;;
+	branch_icon='' user_icon='@' model_icon='' effort_icon='' ctx_icon='' venv_icon='' direnv_icon='' pr_icon='' inbox_icon='' ;;
 nerd)
 	frames=('' '' '' '' '' '')
-	branch_icon=' ' user_icon=' ' model_icon='󰚩 ' effort_icon=' ' ctx_icon='󰓅 ' venv_icon=' ' direnv_icon=' ' pr_icon=' ' ;;
+	branch_icon=' ' user_icon=' ' model_icon='󰚩 ' effort_icon=' ' ctx_icon='󰓅 ' venv_icon=' ' direnv_icon=' ' pr_icon=' ' inbox_icon='󰂚 ' ;;
 *)
 	frames=('-' '\' '|' '/')
-	branch_icon='' user_icon='@' model_icon='' effort_icon='' ctx_icon='' venv_icon='' direnv_icon='' pr_icon='' ;;
+	branch_icon='' user_icon='@' model_icon='' effort_icon='' ctx_icon='' venv_icon='' direnv_icon='' pr_icon='' inbox_icon='' ;;
 esac
 
 out=''
@@ -96,6 +97,24 @@ while [[ -n $d && $d != / ]]; do
 	fi
 	d=${d%/*}
 done
+
+# GitHub-inbox refresh. bin/gh-inbox is a standalone checker (synced to
+# ~/bin by bootstrap) that sweeps every logged-in gh account and writes
+# ~/.cache/gh-inbox/inbox.json; the statusline never fetches inbox data
+# itself, it only schedules the checker and reads its file. Same
+# stamp-first throttle as the fetch/pr-count blocks below, at most once
+# per 10 minutes so handled items clear promptly (~4 requests/account/
+# refresh — well inside the search API's 30/min). Sits outside the git
+# block so the cache stays fresh even when cwd isn't a repo. Explicit
+# ~/bin path with -x, not a PATH lookup — the statusline inherits
+# whatever PATH Claude launched with. Opt out with
+# `git config statusline.inbox false`.
+if command -v gh >/dev/null 2>&1 && [[ -x $HOME/bin/gh-inbox ]] &&
+	[[ $(git -C "$cwd" config --get statusline.inbox 2>/dev/null) != false ]] &&
+	[[ -z $(find "$HOME/.claude" -maxdepth 1 -name statusline-inbox.stamp -mmin -10 2>/dev/null) ]] &&
+	touch "$HOME/.claude/statusline-inbox.stamp" 2>/dev/null; then
+	("$HOME/bin/gh-inbox" >/dev/null 2>&1 </dev/null &)
+fi
 
 toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
 if [[ -n $toplevel ]]; then
@@ -257,6 +276,28 @@ if [[ -n $toplevel ]]; then
 		' "$HOME/.config/gh/hosts.yml" 2>/dev/null)
 	fi
 	[[ -n $gh_user ]] && out+=" ${grey}as${reset} ${magenta}${user_icon}${gh_user}${reset}"
+
+	# Inbox badge: items in THIS repo that need me, read from the gh-inbox
+	# cache the block above keeps fresh — never fetched here (the render
+	# path runs every second and must stay pure-read). Count = todo
+	# (review requests, assignments, invites; persist until resolved on
+	# GitHub) + fyi (unread mentions/replies; clear when read there).
+	# Hidden when zero, absent, or the cache is older than 25 min — a dead
+	# checker must not show a frozen count, and one find covers missing
+	# and stale in a single test.
+	inbox_file="${XDG_CACHE_HOME:-$HOME/.cache}/gh-inbox/inbox.json"
+	if [[ -n $(find "$inbox_file" -mmin -25 2>/dev/null) ]]; then
+		inbox=$(jq -r --arg r "$repo" \
+			'.repos[$r] | if . then .todo + .fyi else empty end' \
+			"$inbox_file" 2>/dev/null)
+		if [[ $inbox =~ ^[0-9]+$ ]] && (( inbox > 0 )); then
+			if [[ -n $inbox_icon ]]; then
+				out+=" ${grey}${inbox_icon}${reset}${yellow}${inbox}${reset}"
+			else
+				out+=" ${grey}inbox${reset} ${yellow}${inbox}${reset}"
+			fi
+		fi
+	fi
 else
 	out+="${green}${cwd/#$HOME/~}${reset}"
 fi

--- a/bin/gh-inbox
+++ b/bin/gh-inbox
@@ -8,23 +8,22 @@
 #
 #   ${XDG_CACHE_HOME:-~/.cache}/gh-inbox/inbox.json
 #   { "updated": "…Z", "repos": { "org/repo": { "todo": N, "fyi": N,
-#     "items": [ { "class", "type", "title", "reason", "url" } ] } } }
+#     "items": [ { "class", "type", "title", "reason", "url", "account" } ] } } }
 #
-# Two item classes with different clearing rules, both with GitHub as the
-# only source of truth — no local read/dismiss state:
+# Everything counted is a live PR, issue, or discussion — never a
+# notification event. GitHub's notifications feed is deliberately not used:
+# its unread flag clears on a glance (or an email), which says nothing
+# about whether the item still needs me. Two classes, both cleared only by
+# the state of the item itself, no local read/dismiss state:
 #
-#   todo — review requests, assignments, repo invitations. Ground truth of
-#          the obligation: an item drops out exactly when it is resolved on
-#          GitHub (review submitted, closed/unassigned, invite accepted).
-#          Glancing at it can't dismiss it.
-#   fyi  — unread notifications where I'm tagged or participating (mention,
-#          team_mention, author, comment, manual). Cleared by GitHub's own
-#          read state; unsubscribing/muting a thread stops these entirely,
-#          so opt-outs are respected for free. Passive reasons (subscribed,
-#          ci_activity, state_change) are dropped as noise, and the reasons
-#          the todo queries own (review_requested, assign, invitation) are
-#          dropped to avoid double counting. The notifications feed is the
-#          one API that unifies issues, PRs, AND Discussions.
+#   todo — PRs awaiting my review, issues/PRs assigned to me, repo
+#          invitations. Ground truth of the obligation: an item drops out
+#          exactly when it is resolved on GitHub (review submitted,
+#          closed/unassigned, invite accepted). Not opt-out-able.
+#   fyi  — open PRs, issues, and discussions that @mention me. Clears when
+#          the item is closed/merged, or when I opt out by unsubscribing
+#          from the thread on GitHub — the GraphQL viewerSubscription field
+#          is checked, so an Unsubscribe click is respected here too.
 #
 # Design rules:
 #   - Silent always. This usually runs detached from a statusline; nothing
@@ -33,12 +32,19 @@
 #   - No cadence logic. Running it refreshes, full stop; callers own the
 #     schedule (the statusline throttles itself with a stamp file), and a
 #     manual run is a forced refresh.
-#   - All-or-nothing per account: an account contributes only when all four
-#     of its queries succeed, so a partial failure can't make that
-#     account's items vanish and read as "handled".
-#   - The cache is rewritten only when at least one account fully answered.
-#     Offline keeps the previous contents: stale beats a false zero, and
-#     readers gate on the file's mtime to catch a dead checker.
+#   - Trust no token: `gh auth token --user X` can hand back a token that
+#     belongs to a DIFFERENT account (observed live — a stale keyring slot
+#     returned another user's token). Every account's token is verified
+#     against `api user` first; a mismatch fails the account, because
+#     queries as the wrong identity return silently incomplete results,
+#     not errors.
+#   - All-or-nothing per account: an account contributes fresh items only
+#     when its identity check and all four queries succeed. A failed
+#     account's items are carried forward from the previous cache instead
+#     — last verified truth beats both a false zero and a frozen file.
+#   - The cache is rewritten only when at least one account fully
+#     answered; offline keeps the previous contents untouched, and readers
+#     gate on the file's mtime to catch a dead checker.
 
 command -v jq >/dev/null 2>&1 || exit 0
 command -v gh >/dev/null 2>&1 || exit 0
@@ -63,64 +69,102 @@ accounts=$(awk '
 
 cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gh-inbox"
 mkdir -p "$cache_dir" 2>/dev/null || exit 0
+inbox_file="$cache_dir/inbox.json"
 
-# fetch <token> <endpoint> <filter> — GET the endpoint as the account the
-# token belongs to and normalize the response to a JSON array of
-# {repo, class, type, title, reason, url}. Fails if either step does, so
-# the caller can drop the whole account (all-or-nothing rule above).
+# fetch <token> <endpoint> <account> <filter> — GET the endpoint and
+# normalize the response to a JSON array of {repo, class, type, title,
+# reason, url, account}. Fails if either step does, so the caller can
+# fail the whole account (all-or-nothing rule above).
 fetch() {
 	local resp
 	resp=$(GH_TOKEN=$1 gh api "$2" 2>/dev/null) || return 1
-	jq -c "$3" <<<"$resp" 2>/dev/null
+	jq -c --arg account "$3" "$4" <<<"$resp" 2>/dev/null
 }
 
-# Normalizers. Search results carry only an API repository_url, so the
-# org/repo key is its tail. The review-requested query is type:pr by
-# construction; the assignee query mixes issues and PRs, told apart by the
-# .pull_request stub.
+# REST normalizers. Search results carry only an API repository_url, so
+# the org/repo key is its tail. The review-requested query is type:pr by
+# construction; the assignee query mixes issues and PRs, told apart by
+# the .pull_request stub.
 review_jq='[.items[] | {repo: (.repository_url | sub("^.*/repos/"; "")),
 	class: "todo", type: "pr", title: .title,
-	reason: "review_requested", url: .html_url}]'
+	reason: "review_requested", url: .html_url, account: $account}]'
 assign_jq='[.items[] | {repo: (.repository_url | sub("^.*/repos/"; "")),
 	class: "todo", type: (if .pull_request then "pr" else "issue" end),
-	title: .title, reason: "assigned", url: .html_url}]'
+	title: .title, reason: "assigned", url: .html_url, account: $account}]'
 invite_jq='[.[] | {repo: .repository.full_name, class: "todo",
 	type: "invite", title: ("invitation to " + .repository.full_name),
-	reason: "invitation", url: .html_url}]'
-# Notification subject URLs are API URLs (api.github.com/repos/…/pulls/N),
-# so rewrite to the web form; Discussions ship a null subject.url (REST API
-# gap), which falls back to the repo page.
-notif_jq='[.[]
-	| select(.reason == "mention" or .reason == "team_mention"
-		or .reason == "author" or .reason == "comment" or .reason == "manual")
-	| {repo: .repository.full_name, class: "fyi",
-		type: ({PullRequest: "pr", Issue: "issue", Discussion: "discussion"}[.subject.type]
-			// (.subject.type | ascii_downcase)),
-		title: .subject.title, reason: .reason,
-		url: (if .subject.url then (.subject.url
-			| sub("//api\\.github\\.com/repos/"; "//github.com/")
-			| sub("/pulls/"; "/pull/"))
-			else .repository.html_url end)}]'
+	reason: "invitation", url: .html_url, account: $account}]'
 
-chunks='' ok=''
+# Mentions go through GraphQL, not REST search, for one reason:
+# viewerSubscription. It reports the queried account's own subscription
+# to each thread, so an Unsubscribe/Ignore on GitHub drops the item —
+# that's the opt-out. type: ISSUE covers issues AND PRs (told apart by
+# __typename); discussions are a separate search type and carry a
+# closed flag instead of a state qualifier.
+mention_gql='query($qi: String!, $qd: String!) {
+	issues: search(query: $qi, type: ISSUE, first: 100) { nodes {
+		__typename
+		... on Issue { title url repository { nameWithOwner } viewerSubscription }
+		... on PullRequest { title url repository { nameWithOwner } viewerSubscription } } }
+	discussions: search(query: $qd, type: DISCUSSION, first: 100) { nodes {
+		... on Discussion { title url closed repository { nameWithOwner } viewerSubscription } } }
+}'
+mention_jq='[
+	(.data.issues.nodes[] | select(.url)
+		| select(.viewerSubscription != "UNSUBSCRIBED" and .viewerSubscription != "IGNORED")
+		| {repo: .repository.nameWithOwner, class: "fyi",
+			type: (if .__typename == "PullRequest" then "pr" else "issue" end),
+			title: .title, reason: "mentioned", url: .url, account: $account}),
+	(.data.discussions.nodes[] | select(.url) | select(.closed | not)
+		| select(.viewerSubscription != "UNSUBSCRIBED" and .viewerSubscription != "IGNORED")
+		| {repo: .repository.nameWithOwner, class: "fyi", type: "discussion",
+			title: .title, reason: "mentioned", url: .url, account: $account})
+]'
+
+chunks='' ok='' failed=''
 for account in $accounts; do
-	token=$(gh auth token --user "$account" 2>/dev/null)
-	[[ -n $token ]] || continue
-	review=$(fetch "$token" "search/issues?q=type:pr+state:open+review-requested:${account}&per_page=100" "$review_jq") || continue
-	assigned=$(fetch "$token" "search/issues?q=state:open+assignee:${account}&per_page=100" "$assign_jq") || continue
-	invites=$(fetch "$token" "user/repository_invitations?per_page=100" "$invite_jq") || continue
-	notifs=$(fetch "$token" "notifications?per_page=100" "$notif_jq") || continue
-	chunks+="$review"$'\n'"$assigned"$'\n'"$invites"$'\n'"$notifs"$'\n'
-	ok=1
+	fail=1
+	while :; do  # single-pass; break = this account failed
+		token=$(gh auth token --user "$account" 2>/dev/null)
+		[[ -n $token ]] || break
+		# Identity check — see design rules. Logins compare
+		# case-insensitively (GitHub treats them that way).
+		login=$(GH_TOKEN=$token gh api user --jq .login 2>/dev/null)
+		[[ -n $login ]] || break
+		[[ $(tr '[:upper:]' '[:lower:]' <<<"$login") == "$(tr '[:upper:]' '[:lower:]' <<<"$account")" ]] || break
+		review=$(fetch "$token" "search/issues?q=type:pr+state:open+review-requested:${account}&per_page=100" "$account" "$review_jq") || break
+		assigned=$(fetch "$token" "search/issues?q=state:open+assignee:${account}&per_page=100" "$account" "$assign_jq") || break
+		invites=$(fetch "$token" "user/repository_invitations?per_page=100" "$account" "$invite_jq") || break
+		resp=$(GH_TOKEN=$token gh api graphql \
+			-f qi="mentions:${account} is:open" \
+			-f qd="mentions:${account}" \
+			-f query="$mention_gql" 2>/dev/null) || break
+		mentions=$(jq -c --arg account "$account" "$mention_jq" <<<"$resp" 2>/dev/null) || break
+		chunks+="$review"$'\n'"$assigned"$'\n'"$invites"$'\n'"$mentions"$'\n'
+		ok=1 fail=''
+		break
+	done
+	[[ -n $fail ]] && failed+="$account"$'\n'
 done
 [[ -n $ok ]] || exit 0
 
+# Carry a failed account's items forward from the previous cache (repo is
+# reconstructed from the map key; items written before account tags
+# existed can't be attributed and just age out).
+if [[ -n $failed && -r $inbox_file ]]; then
+	failed_json=$(jq -Rn '[inputs | select(length > 0)]' <<<"$failed" 2>/dev/null)
+	carried=$(jq -c --argjson failed "${failed_json:-[]}" '
+		[.repos // {} | to_entries[] | .key as $r | .value.items[]
+			| select(.account as $a | $failed | index($a)) | . + {repo: $r}]
+	' "$inbox_file" 2>/dev/null) && chunks+="$carried"$'\n'
+fi
+
 # Merge the accounts' streams. todo sorts before fyi so unique_by — which
 # keeps each URL's first occurrence — makes the obligation win when the
-# same item is both (assigned PR someone also mentioned me on), and an
-# item visible to both accounts counts once. Zero items across the board
-# still writes (an empty repos map is a true zero — the accounts answered).
-tmp="$cache_dir/inbox.json.tmp"
+# same item is both (assigned PR that also mentions me), and an item
+# visible to both accounts counts once. Zero items across the board still
+# writes (an empty repos map is a true zero — the accounts answered).
+tmp="$inbox_file.tmp"
 if jq -s --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
 	add
 	| sort_by(if .class == "todo" then 0 else 1 end)
@@ -133,7 +177,7 @@ if jq -s --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
 	| from_entries
 	| {updated: $now, repos: .}
 ' <<<"$chunks" >"$tmp" 2>/dev/null && [[ -s $tmp ]]; then
-	mv -f "$tmp" "$cache_dir/inbox.json" 2>/dev/null
+	mv -f "$tmp" "$inbox_file" 2>/dev/null
 else
 	rm -f "$tmp" 2>/dev/null
 fi

--- a/bin/gh-inbox
+++ b/bin/gh-inbox
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# gh-inbox — cross-account GitHub inbox checker.
+#
+# Sweeps every account logged into the gh CLI and distills "what needs my
+# attention" into one JSON file that consumers (the Claude Code statusline,
+# a future TUI, anything with jq) read instead of talking to GitHub:
+#
+#   ${XDG_CACHE_HOME:-~/.cache}/gh-inbox/inbox.json
+#   { "updated": "…Z", "repos": { "org/repo": { "todo": N, "fyi": N,
+#     "items": [ { "class", "type", "title", "reason", "url" } ] } } }
+#
+# Two item classes with different clearing rules, both with GitHub as the
+# only source of truth — no local read/dismiss state:
+#
+#   todo — review requests, assignments, repo invitations. Ground truth of
+#          the obligation: an item drops out exactly when it is resolved on
+#          GitHub (review submitted, closed/unassigned, invite accepted).
+#          Glancing at it can't dismiss it.
+#   fyi  — unread notifications where I'm tagged or participating (mention,
+#          team_mention, author, comment, manual). Cleared by GitHub's own
+#          read state; unsubscribing/muting a thread stops these entirely,
+#          so opt-outs are respected for free. Passive reasons (subscribed,
+#          ci_activity, state_change) are dropped as noise, and the reasons
+#          the todo queries own (review_requested, assign, invitation) are
+#          dropped to avoid double counting. The notifications feed is the
+#          one API that unifies issues, PRs, AND Discussions.
+#
+# Design rules:
+#   - Silent always. This usually runs detached from a statusline; nothing
+#     watches stdout and a transient failure must not spam anything. Every
+#     probe is guarded, errors are discarded, exit is always 0.
+#   - No cadence logic. Running it refreshes, full stop; callers own the
+#     schedule (the statusline throttles itself with a stamp file), and a
+#     manual run is a forced refresh.
+#   - All-or-nothing per account: an account contributes only when all four
+#     of its queries succeed, so a partial failure can't make that
+#     account's items vanish and read as "handled".
+#   - The cache is rewritten only when at least one account fully answered.
+#     Offline keeps the previous contents: stale beats a false zero, and
+#     readers gate on the file's mtime to catch a dead checker.
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+
+hosts="$HOME/.config/gh/hosts.yml"
+[[ -r $hosts ]] || exit 0
+
+# Every logged-in account: the keys of the `users:` map in hosts.yml. The
+# awk is indent-sensitive (users: at 4 spaces, account keys at 8) so the
+# host block's own `user:` key — the single ACTIVE account — can't match.
+# Tokens are pinned per API call with GH_TOKEN, never `gh auth switch`:
+# the active account is someone else's state and this script runs in the
+# background.
+accounts=$(awk '
+	/^github\.com:/ { in_host = 1; next }
+	in_host && /^[^[:space:]]/ { in_host = 0; in_users = 0 }
+	in_host && $1 == "users:" { in_users = 1; next }
+	in_users && /^        [^[:space:]]+:$/ { u = $1; sub(/:$/, "", u); print u; next }
+	in_users && /^    [^[:space:]]/ { in_users = 0 }
+' "$hosts" 2>/dev/null)
+[[ -n $accounts ]] || exit 0
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gh-inbox"
+mkdir -p "$cache_dir" 2>/dev/null || exit 0
+
+# fetch <token> <endpoint> <filter> — GET the endpoint as the account the
+# token belongs to and normalize the response to a JSON array of
+# {repo, class, type, title, reason, url}. Fails if either step does, so
+# the caller can drop the whole account (all-or-nothing rule above).
+fetch() {
+	local resp
+	resp=$(GH_TOKEN=$1 gh api "$2" 2>/dev/null) || return 1
+	jq -c "$3" <<<"$resp" 2>/dev/null
+}
+
+# Normalizers. Search results carry only an API repository_url, so the
+# org/repo key is its tail. The review-requested query is type:pr by
+# construction; the assignee query mixes issues and PRs, told apart by the
+# .pull_request stub.
+review_jq='[.items[] | {repo: (.repository_url | sub("^.*/repos/"; "")),
+	class: "todo", type: "pr", title: .title,
+	reason: "review_requested", url: .html_url}]'
+assign_jq='[.items[] | {repo: (.repository_url | sub("^.*/repos/"; "")),
+	class: "todo", type: (if .pull_request then "pr" else "issue" end),
+	title: .title, reason: "assigned", url: .html_url}]'
+invite_jq='[.[] | {repo: .repository.full_name, class: "todo",
+	type: "invite", title: ("invitation to " + .repository.full_name),
+	reason: "invitation", url: .html_url}]'
+# Notification subject URLs are API URLs (api.github.com/repos/…/pulls/N),
+# so rewrite to the web form; Discussions ship a null subject.url (REST API
+# gap), which falls back to the repo page.
+notif_jq='[.[]
+	| select(.reason == "mention" or .reason == "team_mention"
+		or .reason == "author" or .reason == "comment" or .reason == "manual")
+	| {repo: .repository.full_name, class: "fyi",
+		type: ({PullRequest: "pr", Issue: "issue", Discussion: "discussion"}[.subject.type]
+			// (.subject.type | ascii_downcase)),
+		title: .subject.title, reason: .reason,
+		url: (if .subject.url then (.subject.url
+			| sub("//api\\.github\\.com/repos/"; "//github.com/")
+			| sub("/pulls/"; "/pull/"))
+			else .repository.html_url end)}]'
+
+chunks='' ok=''
+for account in $accounts; do
+	token=$(gh auth token --user "$account" 2>/dev/null)
+	[[ -n $token ]] || continue
+	review=$(fetch "$token" "search/issues?q=type:pr+state:open+review-requested:${account}&per_page=100" "$review_jq") || continue
+	assigned=$(fetch "$token" "search/issues?q=state:open+assignee:${account}&per_page=100" "$assign_jq") || continue
+	invites=$(fetch "$token" "user/repository_invitations?per_page=100" "$invite_jq") || continue
+	notifs=$(fetch "$token" "notifications?per_page=100" "$notif_jq") || continue
+	chunks+="$review"$'\n'"$assigned"$'\n'"$invites"$'\n'"$notifs"$'\n'
+	ok=1
+done
+[[ -n $ok ]] || exit 0
+
+# Merge the accounts' streams. todo sorts before fyi so unique_by — which
+# keeps each URL's first occurrence — makes the obligation win when the
+# same item is both (assigned PR someone also mentioned me on), and an
+# item visible to both accounts counts once. Zero items across the board
+# still writes (an empty repos map is a true zero — the accounts answered).
+tmp="$cache_dir/inbox.json.tmp"
+if jq -s --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+	add
+	| sort_by(if .class == "todo" then 0 else 1 end)
+	| unique_by(.url)
+	| group_by(.repo)
+	| map({key: .[0].repo, value: {
+		todo: (map(select(.class == "todo")) | length),
+		fyi: (map(select(.class == "fyi")) | length),
+		items: map(del(.repo))}})
+	| from_entries
+	| {updated: $now, repos: .}
+' <<<"$chunks" >"$tmp" 2>/dev/null && [[ -s $tmp ]]; then
+	mv -f "$tmp" "$cache_dir/inbox.json" 2>/dev/null
+else
+	rm -f "$tmp" 2>/dev/null
+fi
+exit 0


### PR DESCRIPTION
## Summary
- `bin/gh-inbox`: standalone cross-account GitHub inbox checker — sweeps every logged-in gh account for open PRs, issues, and discussions needing attention and writes `~/.cache/gh-inbox/inbox.json`.
- Statusline gains an `inbox N` segment (nerd: bell glyph 󰂚) that reads the gh-inbox cache; red when there are to-dos, yellow when only FYIs.
- The statusline never fetches inbox data itself — it schedules `~/bin/gh-inbox` in the background at most once per 10 minutes via the same stamp-first throttle as the fetch/pr-count blocks (`~/.claude/statusline-inbox.stamp`). Opt out with `git config statusline.inbox false`.
- Counts live PRs/issues/discussions rather than notifications, so handled items clear promptly.

Rebased onto master post-#6, so all inbox polling rides gh https tokens — no ssh-agent / 1Password involvement.

## Test plan
- [x] `bash -n .claude/statusline.sh` on the rebased branch
- [x] Rebase conflict resolution keeps both the effort segment (master) and the inbox segment (branch); icon arms carry both `effort_icon` and `inbox_icon`
- [ ] CI (bats on ubuntu + macos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)