### PR TITLE
🧰 chore: fix Brewfile drift surfaced by the new brew bundle script

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -177,7 +177,7 @@ cask 'micro-snitch'
 cask 'microsoft-teams' # Microsoft Teams
 cask 'moom'
 cask 'namechanger'
-cask 'neardrop' # AirDrop-like sharing with nearby Android and Windows devices
+cask 'neardrop' # AirDrop-like sharing with nearby Android and Windows devices (needs one-time: brew trust grishka/grishka)
 cask 'ngrok'
 cask 'nzbvortex'
 cask 'openaudible' # Audible audiobook manager and converter
@@ -202,7 +202,7 @@ cask 'simplenote'
 cask 'slack'
 cask 'snagit'
 cask 'sourcetree'
-cask 'spark'
+cask 'spark-app'
 cask 'spotify'
 cask 'steam'
 cask 'suspicious-package'


### PR DESCRIPTION
The Phase 2 run_onchange script's first real run caught two stale Brewfile entries: the upstream `spark`→`spark-app` cask rename, and `neardrop`'s tap now requiring a one-time `brew trust grishka/grishka` under newer Homebrew (documented on the cask line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)