### PR TITLE
🧰 chore: Brewfile drift round 2 — claude-code cask conflict, comfy/macvim renames

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -140,9 +140,8 @@ cask 'carbon-copy-cloner'
 cask 'ccmenu'
 cask 'chromedriver'
 cask 'claude' # Anthropic Claude desktop app
-cask 'claude-code' # Anthropic Claude Code CLI
 cask 'codex' # OpenAI Codex desktop app
-cask 'comfyui' # Node-based UI for Stable Diffusion / local AI image generation
+cask 'comfy' # Node-based UI for Stable Diffusion / local AI image generation
 cask 'daisydisk'
 cask 'deluge'
 cask 'displaylink' # DisplayLink USB graphics driver
@@ -172,7 +171,7 @@ cask 'kaleidoscope'
 cask 'libreoffice'
 cask 'little-snitch'
 cask 'lm-studio' # GUI for running local LLMs
-cask 'macvim'
+cask 'macvim-app'
 cask 'micro-snitch'
 cask 'microsoft-teams' # Microsoft Teams
 cask 'moom'


### PR DESCRIPTION
Second batch surfaced by the run_onchange brew bundle script: the `claude-code` cask permanently conflicts with the npm-installed CLI the Brewfile itself prescribes (removed; npm stays the channel), plus the `comfyui`→`comfy` and `macvim`→`macvim-app` upstream renames.

Remaining known-failing entry is `daisydisk`, which just needs an interactive sudo prompt — it will succeed on the next manual `dotfiles` run in a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)