### PR TITLE
Route git-https to the right GitHub account per org path

### DIFF
--- a/bin/executable_git-credential-gh-user
+++ b/bin/executable_git-credential-gh-user
@@ -1,0 +1,19 @@
+#!/bin/sh
+# git credential helper: serve the gh-keyring token for the username git
+# asks for (pinned per URL via credential.<url>.username in gitconfig),
+# regardless of which gh account is currently active. gh's own helper only
+# answers for the active account, which is why this exists. Declines
+# silently — no username pinned, gh missing, or account not logged in —
+# so the next helper in the chain can answer.
+[ "$1" = get ] || exit 0
+
+user=
+while IFS='=' read -r key value; do
+  [ "$key" = username ] && user=$value
+done
+
+[ -n "$user" ] || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+token=$(gh auth token --user "$user" 2>/dev/null) || exit 0
+[ -n "$token" ] || exit 0
+printf 'username=%s\npassword=%s\n' "$user" "$token"

--- a/dot_gitconfig.local.tmpl
+++ b/dot_gitconfig.local.tmpl
@@ -25,6 +25,26 @@
 	path = ~/.gitconfig-ica
 [commit]
 	gpgsign = true
+
+# Route git-over-HTTPS to the right GitHub account (the gh() wrapper in
+# ~/.functions, but for plain git). The Xcode CLT system gitconfig
+# hardwires osxkeychain, which answers with whichever account last cached
+# a credential — background tooling (e.g. Claude Code's plugin marketplace
+# updater) then clones private work repos as the wrong user and gets
+# "repository not found". Reset the helper list: git-credential-gh-user
+# (~/bin) serves the pinned account's token straight from gh's keyring,
+# and gh's own helper covers unpinned URLs with the active account.
+[credential "https://github.com"]
+	helper =
+	helper = !$HOME/bin/git-credential-gh-user
+	helper = !gh auth git-credential
+	useHttpPath = true
+[credential "https://github.com/icanalytica"]
+	username = icaevan
+[credential "https://github.com/icarichie"]
+	username = icaevan
+[credential "https://github.com/hadees"]
+	username = hadees
 {{- end }}
 {{- if eq .machineClass "wsl" }}
 [core]


### PR DESCRIPTION
## Summary
- The Xcode CLT system gitconfig hardwires `osxkeychain`, which answers github.com HTTPS with whichever account last cached a credential — background tooling (Claude Code's plugin marketplace updater) then cloned private work repos as the personal account, got "repository not found", and tore down its marketplace cache, silently disabling every work plugin.
- Adds `~/bin/git-credential-gh-user`, a small credential helper that serves the token for the username git requests, straight from gh's keyring (`gh auth token --user`); gh's bundled helper only answers for the *active* account, so it can't do this.
- `dot_gitconfig.local.tmpl` (mac class only) resets the github.com helper list to: the new helper, then `gh auth git-credential` as fallback, with `useHttpPath` and per-org-path `username` pins. Plain-git behavior for unpinned URLs is unchanged (active gh account). No tokens at rest anywhere.

## Test plan
- [x] shellcheck clean on the helper
- [x] `git credential fill` with a work-org path resolves the work username + token while the personal account is active; a personal path still resolves to the personal account
- [x] The previously-failing `claude plugin marketplace update` now succeeds bare, no env-var token injection
- [x] `bats tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)