### PR TITLE
Apply work identity to HTTPS work-org remotes

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -34,4 +34,5 @@ com.googlecode.iterm2.plist
 .claude
 CLAUDE.md
 .chezmoiscripts/**
+.config/namecheap
 {{ end -}}

--- a/dot_aliases
+++ b/dot_aliases
@@ -169,5 +169,10 @@ alias reload="exec ${SHELL} -l"
 # Sync dotfiles repo to $HOME (chezmoi's sourceDir points at the clone)
 alias dotfiles='chezmoi apply'
 
+# namecheap-cli with credentials injected per-invocation from 1Password.
+# ~/.config/namecheap/env holds op:// references, not secrets; `op run`
+# resolves them into just this process. One biometric okay per app unlock.
+alias nc-cli='op run --env-file ~/.config/namecheap/env -- namecheap-cli'
+
 # Print each PATH entry on a separate line
 alias path='echo -e ${PATH//:/\\n}'

--- a/dot_config/namecheap/env
+++ b/dot_config/namecheap/env
@@ -1,0 +1,4 @@
+# 1Password secret REFERENCES for namecheap-cli — not secrets, safe to commit.
+# Resolved at runtime by `op run --env-file` (see nc-cli alias in .aliases).
+NAMECHEAP_USERNAME="op://Personal/www.namecheap.com/username"
+NAMECHEAP_API_KEY="op://Personal/www.namecheap.com/API/credential"

--- a/dot_gitconfig.local.tmpl
+++ b/dot_gitconfig.local.tmpl
@@ -18,10 +18,15 @@
 	allowedSignersFile = ~/.config/git/allowed_signers
 
 # Work identity follows the remote: any repo whose remote uses the
-# github-icaevan SSH alias gets the icanalytica identity (requires git 2.36+).
+# github-icaevan SSH alias or an HTTPS URL under a work org gets the
+# icanalytica identity (requires git 2.36+).
 [includeIf "hasconfig:remote.*.url:github-icaevan:*/**"]
 	path = ~/.gitconfig-ica
 [includeIf "hasconfig:remote.*.url:git@github-icaevan:*/**"]
+	path = ~/.gitconfig-ica
+[includeIf "hasconfig:remote.*.url:https://github.com/icanalytica/**"]
+	path = ~/.gitconfig-ica
+[includeIf "hasconfig:remote.*.url:https://github.com/icarichie/**"]
 	path = ~/.gitconfig-ica
 [commit]
 	gpgsign = true


### PR DESCRIPTION
## Why

The `includeIf` hooks in `dot_gitconfig.local.tmpl` only matched the `github-icaevan:` SSH alias, but work repos cloned over HTTPS (icanalytica standardizes on HTTPS remotes) fell through to the personal identity — commits landed with the wrong email and signing key.

## What

Add two more `includeIf "hasconfig:remote.*.url:..."` rules matching `https://github.com/icanalytica/**` and `https://github.com/icarichie/**`, mirroring the org list the credential-routing section below already pins to `icaevan`. Requires git 2.36+ like the existing rules.

Already applied live on this machine and verified: an HTTPS icanalytica clone now resolves `user.email` to the work address, `github.user` to `icaevan`, and the icaevan signing key. `chezmoi diff` shows source and target in sync for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)